### PR TITLE
typo

### DIFF
--- a/_posts/2018-11-13-12-factor-terraform.md
+++ b/_posts/2018-11-13-12-factor-terraform.md
@@ -48,7 +48,7 @@ My solution is to create an empty [workspace](https://www.terraform.io/docs/stat
 
 #### Unit Test: ```awk | sed```???
 
-I will admit that I don't have a good solution for unit testing. There are a couple defunct projects on github that were focused on providing unit test frameworks for terraform. At the moment this is a minor frustration for me and I keep telling myself that I will write my own test harness *when I have the time*. But, despite the lack of an existing solution in the ecosystem, it should be easy enough to recognize the potential for unit testing the plan output by the build step above. The configuration input into the plan is know at design time and the empty workspace acts as a surrogate mocking framework for the cloud provider. At a most basic level I can see using text parsing to run assertions against the output of the ```terraform plan``` command.
+I will admit that I don't have a good solution for unit testing. There are a couple defunct projects on github that were focused on providing unit test frameworks for terraform. At the moment this is a minor frustration for me and I keep telling myself that I will write my own test harness *when I have the time*. But, despite the lack of an existing solution in the ecosystem, it should be easy enough to recognize the potential for unit testing the plan output by the build step above. The configuration input into the plan is known at design time and the empty workspace acts as a surrogate mocking framework for the cloud provider. At a most basic level I can see using text parsing to run assertions against the output of the ```terraform plan``` command.
 
 #### Publish the artifact
 


### PR DESCRIPTION
"The configuration input into the plan is know at design time" => "The configuration input into the plan is known at design time".
I'm not going to fix it, but contemporaneously is not a word I see commonly used...not saying I had to look it up but most people would.  OK I had to look it up 🎓 📓 